### PR TITLE
ci(fix): push to GHCR before DockerHub to avoid rate-limit impacts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,52 +38,52 @@ jobs:
         driver-opts: |
           image=moby/buildkit:buildx-stable-1
           network=host
+    - name: Build & Push (non-main branch)
+      run: |
+          set -ex
+          make docker-multi COMMIT=${{ github.sha }} DOCKER_REPO=localhost:5000/${{ github.repository }} BUILDX_ACTION=--push
+          
+          docker buildx imagetools create --dry-run -t localhost:5000/${{ github.repository }}:dev localhost:5000/${{ github.repository }}:latest
+          docker buildx imagetools create --dry-run -t localhost:5000/${{ github.repository }}:dev-alpine localhost:5000/${{ github.repository }}:alpine
+      if: github.repository != 'hairyhenderson/sagemcom_fast_exporter' || (github.ref != 'refs/heads/main' && ! startsWith(github.ref, 'refs/tags/'))
     - name: Login to GHCR
       uses: docker/login-action@v3
       with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Login to DockerHub
-      uses: docker/login-action@v3
-      with:
-        username: hairyhenderson
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build & Push (non-main branch)
-      run: |
-        set -ex
-        make docker-multi COMMIT=${{ github.sha }} DOCKER_REPO=localhost:5000/${{ github.repository }} BUILDX_ACTION=--push
-
-        docker buildx imagetools create --dry-run -t localhost:5000/${{ github.repository }}:dev localhost:5000/${{ github.repository }}:latest
-        docker buildx imagetools create --dry-run -t localhost:5000/${{ github.repository }}:dev-alpine localhost:5000/${{ github.repository }}:alpine
-      if: github.repository != 'hairyhenderson/sagemcom_fast_exporter' || github.ref != 'refs/heads/main'
     - name: Build & Push (main/tags)
       run: |
         src_repo=${{ github.repository}}
 
         set -x
-        make docker-multi COMMIT=${{ github.sha }} DOCKER_REPO=${src_repo} BUILDX_ACTION=--push
+        make docker-multi COMMIT=${{ github.sha }} DOCKER_REPO=ghcr.io/${src_repo} BUILDX_ACTION=--push
 
         set -x
-        docker buildx imagetools create -t ghcr.io/${src_repo}:latest ${src_repo}:latest
-        docker buildx imagetools create -t ghcr.io/${src_repo}:alpine ${src_repo}:alpine
+        docker buildx imagetools create -t ${src_repo}:latest ghcr.io/${src_repo}:latest
+        docker buildx imagetools create -t ${src_repo}:alpine ghcr.io/${src_repo}:alpine
       if: github.repository == 'hairyhenderson/sagemcom_fast_exporter' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    - name: Login to DockerHub
+      uses: docker/login-action@v3
+      with:
+        username: hairyhenderson
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Push (tagged release)
       run: |
-        src_repo=${{ github.repository }}
+        repo_name=${{ github.repository }}
         git_tag=${{ github.ref_name }}
         major_version=${git_tag%%\.*}
 
         set -x
-        repo=$src_repo
-        docker buildx imagetools create -t ${repo}:${git_tag} ${src_repo}:latest
-        docker buildx imagetools create -t ${repo}:${major_version} ${src_repo}:latest
-        docker buildx imagetools create -t ${repo}:${git_tag}-alpine ${src_repo}:alpine
-        docker buildx imagetools create -t ${repo}:${major_version}-alpine ${src_repo}:alpine
+        repo=ghcr.io/${repo_name}
+        docker buildx imagetools create -t ${repo}:${git_tag} ghcr.io/${repo_name}:latest
+        docker buildx imagetools create -t ${repo}:${major_version} ghcr.io/${repo_name}:latest
+        docker buildx imagetools create -t ${repo}:${git_tag}-alpine ghcr.io/${repo_name}:alpine
+        docker buildx imagetools create -t ${repo}:${major_version}-alpine ghcr.io/${repo_name}:alpine
 
-        repo=ghcr.io/${{ github.repository }}
-        docker buildx imagetools create -t ${repo}:${git_tag} ${src_repo}:latest
-        docker buildx imagetools create -t ${repo}:${major_version} ${src_repo}:latest
-        docker buildx imagetools create -t ${repo}:${git_tag}-alpine ${src_repo}:alpine
-        docker buildx imagetools create -t ${repo}:${major_version}-alpine ${src_repo}:alpine
+        repo=docker.io/${repo_name}
+        docker buildx imagetools create -t ${repo}:${git_tag} ghcr.io/${repo_name}:latest
+        docker buildx imagetools create -t ${repo}:${major_version} ghcr.io/${repo_name}:latest
+        docker buildx imagetools create -t ${repo}:${git_tag}-alpine ghcr.io/${repo_name}:alpine
+        docker buildx imagetools create -t ${repo}:${major_version}-alpine ghcr.io/${repo_name}:alpine
       if: github.repository == 'hairyhenderson/sagemcom_fast_exporter' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
a couple things:
- we don't need to build the non-main job when on a tag
- dockerhub's rate limits on pushes are awful, so leave that until last so we can at least push to GHCR without getting limited