### PR TITLE
fix: misc JSON handling bugs on Sagemcom F@st 5690

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -258,24 +258,69 @@ func (c *client) apiRequest(ctx context.Context, actions []action) (map[string]r
 
 	// Error in one of the actions
 	if errors.Is(err, ErrRequestAction) {
-		var errs []error
+		errs := actionErrors(actions, reply.Actions)
 
-		for _, action := range reply.Actions {
-			if action.Error != nil {
-				if errors.Is(action.Error, ErrNoError) {
-					continue
-				}
-
-				errs = append(errs, action.Error)
-			}
+		if fatal := withoutUnknownPaths(errs); len(fatal) > 0 {
+			return result, fmt.Errorf("action error(s): %w", errors.Join(fatal...))
 		}
 
+		// An unknown path just means this device doesn't implement that part
+		// of the data model, so report whatever it did return instead of
+		// failing the whole request. Retrying wouldn't help either.
 		if len(errs) > 0 {
-			return result, fmt.Errorf("action error(s): %w", errors.Join(errs...))
+			slog.WarnContext(ctx, "ignoring unimplemented xpath(s)", slog.Any("err", errors.Join(errs...)))
+
+			return result, nil
 		}
 	}
 
 	return result, fmt.Errorf("unknown error: %w", err)
+}
+
+// withoutUnknownPaths returns the errors that aren't XMO_UNKNOWN_PATH_ERR.
+func withoutUnknownPaths(errs []error) []error {
+	fatal := make([]error, 0, len(errs))
+
+	for _, err := range errs {
+		if !errors.Is(err, ErrUnknownPath) {
+			fatal = append(fatal, err)
+		}
+	}
+
+	return fatal
+}
+
+// actionErrors collects the errors reported by individual actions, naming each
+// one by the XPath that was requested, so that a failure identifies the path
+// the router rejected. Actions without an XPath (such as logIn) are named by
+// their method instead.
+func actionErrors(requested []action, responses []actionResp) []error {
+	xpaths := make(map[int]string, len(requested))
+
+	for _, a := range requested {
+		if a.XPath != "" {
+			xpaths[a.ID] = a.XPath
+		} else {
+			xpaths[a.ID] = a.Method
+		}
+	}
+
+	var errs []error
+
+	for _, a := range responses {
+		if a.Error == nil || errors.Is(a.Error, ErrNoError) {
+			continue
+		}
+
+		name, ok := xpaths[a.ID]
+		if !ok {
+			name = fmt.Sprintf("action %d", a.ID)
+		}
+
+		errs = append(errs, fmt.Errorf("%s: %w", name, a.Error))
+	}
+
+	return errs
 }
 
 // loginAction - generate the login action

--- a/client/lite_client.go
+++ b/client/lite_client.go
@@ -88,7 +88,9 @@ func (c *LiteClient) GetDevice(ctx context.Context) (*DeviceResponse, error) {
 				return nil, fmt.Errorf("failed to fetch device info: nil result for xpath %s", cb.XPath)
 			}
 
-			if cb.Result.Code != ErrNoError.Code {
+			// compare by description, not code: some firmware reports
+			// XMO_NO_ERR with a code other than ErrNoError.Code
+			if cb.Result.Description != ErrNoError.Description {
 				return nil, fmt.Errorf("failed to fetch device info for %s: %v", cb.XPath, cb.Result)
 			}
 
@@ -176,7 +178,9 @@ func (c *LiteClient) GetResourceUsage(ctx context.Context) (*ResourceUsage, erro
 				return nil, fmt.Errorf("failed to fetch resource usage: nil result for xpath %s", cb.XPath)
 			}
 
-			if cb.Result.Code != ErrNoError.Code {
+			// compare by description, not code: some firmware reports
+			// XMO_NO_ERR with a code other than ErrNoError.Code
+			if cb.Result.Description != ErrNoError.Description {
 				return nil, fmt.Errorf("failed to fetch resource usage for %s: %v", cb.XPath, cb.Result)
 			}
 

--- a/client/lite_client.go
+++ b/client/lite_client.go
@@ -82,7 +82,7 @@ func (c *LiteClient) GetDevice(ctx context.Context) (*DeviceResponse, error) {
 	// temporary value to unmarshal and copy data
 	d := Device{}
 
-	for _, action := range reply.Actions {
+	for _, action := range succeededActions(reply.Actions) {
 		for _, cb := range action.Callbacks {
 			if cb.Result == nil {
 				return nil, fmt.Errorf("failed to fetch device info: nil result for xpath %s", cb.XPath)
@@ -172,7 +172,7 @@ func (c *LiteClient) GetResourceUsage(ctx context.Context) (*ResourceUsage, erro
 
 	ru := ResourceUsage{}
 
-	for _, action := range reply.Actions {
+	for _, action := range succeededActions(reply.Actions) {
 		for _, cb := range action.Callbacks {
 			if cb.Result == nil {
 				return nil, fmt.Errorf("failed to fetch resource usage: nil result for xpath %s", cb.XPath)
@@ -242,4 +242,19 @@ func (c *LiteClient) GetResourceUsage(ctx context.Context) (*ResourceUsage, erro
 	}
 
 	return &ru, nil
+}
+
+// succeededActions filters out the actions the router rejected. apiRequest has
+// already decided those errors aren't fatal (an unimplemented xpath, say), and
+// their callbacks carry no usable value.
+func succeededActions(actions []actionResp) []actionResp {
+	succeeded := make([]actionResp, 0, len(actions))
+
+	for _, a := range actions {
+		if a.Error == nil || errors.Is(a.Error, ErrNoError) {
+			succeeded = append(succeeded, a)
+		}
+	}
+
+	return succeeded
 }

--- a/client/lite_client.go
+++ b/client/lite_client.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -97,12 +96,6 @@ func (c *LiteClient) GetDevice(ctx context.Context) (*DeviceResponse, error) {
 
 			switch cb.XPath {
 			case xpathDeviceInfo:
-				// replace invalid time format
-				value = bytes.ReplaceAll(value,
-					[]byte("1-01-01T00:00:00+0000"),
-					[]byte("0001-01-01T00:00:00+0000"),
-				)
-
 				err = json.Unmarshal(value, &deviceInfo.Device)
 				if err != nil {
 					return nil, fmt.Errorf("failed to decode %s: %w", cb.XPath, err)

--- a/client/lite_client_test.go
+++ b/client/lite_client_test.go
@@ -5,9 +5,17 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
+
+// withAltNoErrCode rewrites the XMO_NO_ERR code in a canned response to the one
+// some firmware (such as the F@st 5690) reports instead. The description is left
+// alone, so the response still says there was no error.
+func withAltNoErrCode(response string) string {
+	return strings.ReplaceAll(response, `"code": 16777238`, `"code": 16777239`)
+}
 
 var (
 	//go:embed testdata/fast5670/auth_success_response.json
@@ -140,6 +148,27 @@ func TestLiteClientGetDeviceSentinelTimestamps(t *testing.T) {
 	}
 }
 
+// TestLiteClientGetDeviceAltNoErrCode tests that a callback reporting XMO_NO_ERR
+// under a code other than ErrNoError.Code is still treated as a success.
+func TestLiteClientGetDeviceAltNoErrCode(t *testing.T) {
+	t.Parallel()
+
+	lc := createLiteClientToTestServer(t, withAltNoErrCode(deviceSuccessResponse))
+
+	result, err := lc.GetDevice(t.Context())
+	if err != nil {
+		t.Fatalf("GetDevice failed: %v", err)
+	}
+
+	if result.Device.DeviceInfo.Manufacturer != "SagemCom" {
+		t.Errorf("want Manufacturer 'SagemCom', got '%s'", result.Device.DeviceInfo.Manufacturer)
+	}
+
+	if len(result.Device.WiFi.Radios) != 1 {
+		t.Errorf("WiFi Radios are missing")
+	}
+}
+
 // TestLiteClientGetResourceUsage tests the GetResourceUsage method.
 func TestLiteClientGetResourceUsage(t *testing.T) {
 	t.Parallel()
@@ -178,6 +207,28 @@ func TestLiteClientGetResourceUsage(t *testing.T) {
 	}
 
 	// Verify CPU usage
+	if result.CPUUsage != 5 {
+		t.Errorf("want CPUUsage 5, got %d", result.CPUUsage)
+	}
+}
+
+// TestLiteClientGetResourceUsageAltNoErrCode tests that a callback reporting
+// XMO_NO_ERR under a code other than ErrNoError.Code is still treated as a
+// success.
+func TestLiteClientGetResourceUsageAltNoErrCode(t *testing.T) {
+	t.Parallel()
+
+	lc := createLiteClientToTestServer(t, withAltNoErrCode(resourceUsageSuccessResponse))
+
+	result, err := lc.GetResourceUsage(t.Context())
+	if err != nil {
+		t.Fatalf("GetResourceUsage failed: %v", err)
+	}
+
+	if result.TotalMemory != 504160 {
+		t.Errorf("want TotalMemory 504160, got %d", result.TotalMemory)
+	}
+
 	if result.CPUUsage != 5 {
 		t.Errorf("want CPUUsage 5, got %d", result.CPUUsage)
 	}

--- a/client/lite_client_test.go
+++ b/client/lite_client_test.go
@@ -28,6 +28,8 @@ var (
 	deviceErrorResponse string
 	//go:embed testdata/fast5670/resource_usage_success_response.json
 	resourceUsageSuccessResponse string
+	//go:embed testdata/fast5670/resource_usage_unknown_path_response.json
+	resourceUsageUnknownPathResponse string
 	//go:embed testdata/fast5670/resource_usage_error_response.json
 	resourceUsageErrorResponse string
 )
@@ -231,6 +233,84 @@ func TestLiteClientGetResourceUsageAltNoErrCode(t *testing.T) {
 
 	if result.CPUUsage != 5 {
 		t.Errorf("want CPUUsage 5, got %d", result.CPUUsage)
+	}
+}
+
+// TestLiteClientGetResourceUsageUnknownPath tests that XPaths the device
+// doesn't implement are skipped rather than failing the whole request. The
+// F@st 5690 has no Device/DeviceInfo/ProcessStatus/LoadAverage or CPUUsage,
+// but still reports memory and flash usage.
+func TestLiteClientGetResourceUsageUnknownPath(t *testing.T) {
+	t.Parallel()
+
+	lc := createLiteClientToTestServer(t, resourceUsageUnknownPathResponse)
+
+	result, err := lc.GetResourceUsage(t.Context())
+	if err != nil {
+		t.Fatalf("GetResourceUsage failed: %v", err)
+	}
+
+	if result.TotalMemory != 504160 {
+		t.Errorf("want TotalMemory 504160, got %d", result.TotalMemory)
+	}
+
+	if result.FreeMemory != 94440 {
+		t.Errorf("want FreeMemory 94440, got %d", result.FreeMemory)
+	}
+
+	if result.AvailableFlashMemory != 65536 {
+		t.Errorf("want AvailableFlashMemory 65536, got %d", result.AvailableFlashMemory)
+	}
+
+	// the unimplemented XPaths simply leave their values unset
+	if result.LoadAverage != 0 {
+		t.Errorf("want LoadAverage 0, got %f", result.LoadAverage)
+	}
+
+	if result.CPUUsage != 0 {
+		t.Errorf("want CPUUsage 0, got %d", result.CPUUsage)
+	}
+}
+
+// TestLiteClientActionErrorNamesXPath tests that an action error identifies the
+// XPath that failed, instead of only repeating the error code, and that an
+// error other than an unknown XPath still fails the request even when an
+// unknown XPath is reported alongside it.
+func TestLiteClientActionErrorNamesXPath(t *testing.T) {
+	t.Parallel()
+
+	const response = `{
+		"reply": {
+			"uid": 0,
+			"id": 2,
+			"error": {"code": 16777236, "description": "XMO_REQUEST_ACTION_ERR"},
+			"actions": [
+				{
+					"uid": 1,
+					"id": 1,
+					"error": {"code": 1, "description": "XMO_ACCESS_RESTRICTION_ERR"},
+					"callbacks": []
+				},
+				{
+					"uid": 2,
+					"id": 3,
+					"error": {"code": 16777243, "description": "XMO_UNKNOWN_PATH_ERR"},
+					"callbacks": []
+				}
+			]
+		}
+	}`
+
+	lc := createLiteClientToTestServer(t, response)
+
+	_, err := lc.GetResourceUsage(t.Context())
+	if err == nil {
+		t.Fatal("want error for restricted path response, but got none")
+	}
+
+	// action ID 1 is the flash memory XPath
+	if !strings.Contains(err.Error(), xpathFlashMemoryStatus) {
+		t.Errorf("error %q does not name the failing XPath %q", err, xpathFlashMemoryStatus)
 	}
 }
 

--- a/client/lite_client_test.go
+++ b/client/lite_client_test.go
@@ -14,6 +14,8 @@ var (
 	authSuccessResponse string
 	//go:embed testdata/fast5670/device_success_response.json
 	deviceSuccessResponse string
+	//go:embed testdata/fast5670/device_sentinel_timestamp_response.json
+	deviceSentinelTimestampResponse string
 	//go:embed testdata/fast5670/device_error_response.json
 	deviceErrorResponse string
 	//go:embed testdata/fast5670/resource_usage_success_response.json
@@ -104,6 +106,37 @@ func TestLiteClientGetDevice(t *testing.T) {
 
 	if len(device.Optical.Interfaces) != 1 {
 		t.Errorf("Optical Interfaces are missing")
+	}
+}
+
+// TestLiteClientGetDeviceSentinelTimestamps tests that the router's "never set"
+// timestamps survive the round trip through GetDevice as the zero time.
+func TestLiteClientGetDeviceSentinelTimestamps(t *testing.T) {
+	t.Parallel()
+
+	lc := createLiteClientToTestServer(t, deviceSentinelTimestampResponse)
+
+	result, err := lc.GetDevice(t.Context())
+	if err != nil {
+		t.Fatalf("GetDevice failed: %v", err)
+	}
+
+	di := result.Device.DeviceInfo
+
+	if di.FirstUseDate != (time.Time{}) {
+		t.Errorf("FirstUseDate = %v, want the zero time", di.FirstUseDate)
+	}
+
+	if di.BackupTimeStamp != (time.Time{}) {
+		t.Errorf("BackupTimeStamp = %v, want the zero time", di.BackupTimeStamp)
+	}
+
+	if di.CrashHistory.LastCrashDate != (time.Time{}) {
+		t.Errorf("LastCrashDate = %v, want the zero time", di.CrashHistory.LastCrashDate)
+	}
+
+	if want := time.Date(2022, 8, 10, 2, 18, 11, 0, time.UTC); !di.BuildDate.Equal(want) {
+		t.Errorf("BuildDate = %v, want %v", di.BuildDate, want)
 	}
 }
 

--- a/client/testdata/fast5670/device_sentinel_timestamp_response.json
+++ b/client/testdata/fast5670/device_sentinel_timestamp_response.json
@@ -1,0 +1,47 @@
+{
+  "reply": {
+    "uid": 0,
+    "id": 1,
+    "error": {
+      "code": 16777216,
+      "description": "XMO_REQUEST_NO_ERR"
+    },
+    "actions": [
+      {
+        "uid": 1,
+        "id": 0,
+        "error": {
+          "code": 16777238,
+          "description": "XMO_NO_ERR"
+        },
+        "callbacks": [
+          {
+            "uid": 1,
+            "result": {
+              "code": 16777238,
+              "description": "XMO_NO_ERR"
+            },
+            "xpath": "Device/DeviceInfo",
+            "parameters": {
+              "value": {
+                "DeviceInfo": {
+                  "Manufacturer": "SagemCom",
+                  "ModelName": "Fast5670_ABRV",
+                  "ReleaseDate": "1-01-01T00:00:00+0000",
+                  "FirstUseDate": "1-01-01T00:00:00+0000",
+                  "BackupTimeStamp": "0-01-01T00:00:00+0000",
+                  "BuildDate": "2022-08-10T02:18:11Z",
+                  "UpTime": 3455043,
+                  "CrashHistory": {
+                    "LastCrashDate": "1-01-01T00:00:00+0000",
+                    "NumberOfCrash": 0
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/client/testdata/fast5670/resource_usage_unknown_path_response.json
+++ b/client/testdata/fast5670/resource_usage_unknown_path_response.json
@@ -1,0 +1,83 @@
+{
+  "reply": {
+    "uid": 0,
+    "id": 2,
+    "error": {
+      "code": 16777236,
+      "description": "XMO_REQUEST_ACTION_ERR"
+    },
+    "actions": [
+      {
+        "uid": 1,
+        "id": 0,
+        "error": {
+          "code": 16777238,
+          "description": "XMO_NO_ERR"
+        },
+        "callbacks": [
+          {
+            "uid": 1,
+            "result": {
+              "code": 16777238,
+              "description": "XMO_NO_ERR"
+            },
+            "xpath": "Device/DeviceInfo/MemoryStatus",
+            "parameters": {
+              "value": {
+                "MemoryStatus": {
+                  "Total": 504160,
+                  "Free": 94440
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "uid": 2,
+        "id": 1,
+        "error": {
+          "code": 16777238,
+          "description": "XMO_NO_ERR"
+        },
+        "callbacks": [
+          {
+            "uid": 1,
+            "result": {
+              "code": 16777238,
+              "description": "XMO_NO_ERR"
+            },
+            "xpath": "Device/DeviceInfo/FlashMemoryStatus",
+            "parameters": {
+              "value": {
+                "FlashMemoryStatus": {
+                  "Total": 131072,
+                  "Free": 65536
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "uid": 3,
+        "id": 2,
+        "error": {
+          "code": 16777243,
+          "description": "XMO_UNKNOWN_PATH_ERR"
+        },
+        "callbacks": []
+      },
+      {
+        "uid": 4,
+        "id": 3,
+        "error": {
+          "code": 16777243,
+          "description": "XMO_UNKNOWN_PATH_ERR"
+        },
+        "callbacks": []
+      }
+    ],
+    "events": []
+  }
+}

--- a/client/types.go
+++ b/client/types.go
@@ -2850,7 +2850,7 @@ type Radio struct {
 func (r *Radio) UnmarshalJSON(data []byte) error {
 	type alias Radio
 
-	aux := &struct {
+	aux := struct {
 		*alias
 		CurrentOperatingChannelBandwidth string `json:"CurrentOperatingChannelBandwidth"`
 		TransmitPower                    int    `json:"TransmitPower"`

--- a/client/types.go
+++ b/client/types.go
@@ -2858,6 +2858,10 @@ func (r *Radio) UnmarshalJSON(data []byte) error {
 		alias: (*alias)(r),
 	}
 
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
 	if aux.CurrentOperatingChannelBandwidth != "" {
 		if strings.HasSuffix(aux.CurrentOperatingChannelBandwidth, "MHz") {
 			bw, err := strconv.Atoi(aux.CurrentOperatingChannelBandwidth[:len(aux.CurrentOperatingChannelBandwidth)-3])
@@ -2874,10 +2878,6 @@ func (r *Radio) UnmarshalJSON(data []byte) error {
 
 	// Convert TransmitPower from a percentage out of 100 to a ratio out of 1
 	r.TransmitPower = float64(aux.TransmitPower) / 100
-
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -2935,12 +2935,18 @@ func parseTimestamp(s string) (time.Time, error) {
 		return time.Time{}, nil
 	}
 
-	if strings.HasPrefix(s, "0-") {
-		// special-case for year 0
-		s = "000" + s
+	// Router uses "0-..." (year 0) and "1-..." (year 1) as "never set" sentinels.
+	if strings.HasPrefix(s, "0-") || strings.HasPrefix(s, "1-") {
+		return time.Time{}, nil
 	}
 
-	return time.Parse("2006-01-02T15:04:05-0700", s)
+	t, err := time.Parse("2006-01-02T15:04:05-0700", s)
+	if err != nil {
+		// Also accept RFC 3339 (Z suffix), used by some router firmware versions.
+		t, err = time.Parse(time.RFC3339, s)
+	}
+
+	return t, err
 }
 
 func (d *DeviceInfo) UnmarshalJSON(b []byte) error {

--- a/client/types_test.go
+++ b/client/types_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -28,6 +29,29 @@ func TestRadioUnmarshalJSON(t *testing.T) {
 
 	if want := int64(300 * 1024 * 1024); r.MaxBitRate != want {
 		t.Errorf("MaxBitRate = %d, want %d", r.MaxBitRate, want)
+	}
+}
+
+// TestRadioUnmarshalJSONNull verifies that a null radio decodes to zero.
+func TestRadioUnmarshalJSONNull(t *testing.T) {
+	t.Parallel()
+
+	const data = `{"Radios": [null]}`
+
+	var wifi struct {
+		Radios []Radio
+	}
+
+	if err := json.Unmarshal([]byte(data), &wifi); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	if len(wifi.Radios) != 1 {
+		t.Fatalf("Radios = %d, want 1", len(wifi.Radios))
+	}
+
+	if want := (Radio{}); !reflect.DeepEqual(wifi.Radios[0], want) {
+		t.Errorf("Radios[0] = %+v, want the zero value", wifi.Radios[0])
 	}
 }
 

--- a/client/types_test.go
+++ b/client/types_test.go
@@ -1,0 +1,169 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestRadioUnmarshalJSON(t *testing.T) {
+	const data = `{
+		"CurrentOperatingChannelBandwidth": "40MHz",
+		"TransmitPower": 75,
+		"MaxBitRate": 300
+	}`
+
+	var r Radio
+	if err := json.Unmarshal([]byte(data), &r); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	if want := int64(40_000_000); r.CurrentOperatingChannelBandwidth != want {
+		t.Errorf("CurrentOperatingChannelBandwidth = %d, want %d", r.CurrentOperatingChannelBandwidth, want)
+	}
+
+	if want := 0.75; r.TransmitPower != want {
+		t.Errorf("TransmitPower = %v, want %v", r.TransmitPower, want)
+	}
+
+	if want := int64(300 * 1024 * 1024); r.MaxBitRate != want {
+		t.Errorf("MaxBitRate = %d, want %d", r.MaxBitRate, want)
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: time.Time{},
+		},
+		{
+			name: "year 0 sentinel",
+			in:   "0-01-01T00:00:00+0000",
+			want: time.Time{},
+		},
+		{
+			name: "year 1 sentinel",
+			in:   "1-01-01T00:00:00+0000",
+			want: time.Time{},
+		},
+		{
+			name: "zero-padded year 1",
+			in:   "0001-01-01T00:00:00+0000",
+			want: time.Time{},
+		},
+		{
+			name: "rfc3339 with Z suffix",
+			in:   "2024-03-05T12:34:56Z",
+			want: time.Date(2024, 3, 5, 12, 34, 56, 0, time.UTC),
+		},
+		{
+			name: "default layout",
+			in:   "2024-03-05T12:34:56-0700",
+			want: time.Date(2024, 3, 5, 12, 34, 56, 0, time.FixedZone("", -7*60*60)),
+		},
+		{
+			name:    "unparseable",
+			in:      "not a timestamp",
+			want:    time.Time{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTimestamp(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseTimestamp(%q) error = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+
+			if !got.Equal(tt.want) {
+				t.Errorf("parseTimestamp(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseTimestampSentinels verifies that every form of the router's "never
+// set" timestamp yields the zero value.
+func TestParseTimestampSentinels(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		"0-01-01T00:00:00+0000",
+		"1-01-01T00:00:00+0000",
+		"1-01-01T00:00:00Z",
+		"1-01-01T00:00:00-0500",
+	}
+
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseTimestamp(in)
+			if err != nil {
+				t.Fatalf("parseTimestamp(%q) error = %v", in, err)
+			}
+
+			if got != (time.Time{}) {
+				t.Errorf("parseTimestamp(%q) = %v, want the zero time", in, got)
+			}
+		})
+	}
+}
+
+// TestDeviceInfoUnmarshalJSONSentinelTimestamps verifies that the router's
+// "never set" timestamps decode to the zero value, rather than to a year 1
+// timestamp in a fixed zone, so that callers can compare against time.Time{}.
+func TestDeviceInfoUnmarshalJSONSentinelTimestamps(t *testing.T) {
+	t.Parallel()
+
+	const data = `{
+		"FirstUseDate": "1-01-01T00:00:00+0000",
+		"BackupTimeStamp": "0-01-01T00:00:00+0000",
+		"BuildDate": "2022-08-10T02:18:11Z"
+	}`
+
+	var di DeviceInfo
+	if err := json.Unmarshal([]byte(data), &di); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	if di.FirstUseDate != (time.Time{}) {
+		t.Errorf("FirstUseDate = %v, want the zero time", di.FirstUseDate)
+	}
+
+	if di.BackupTimeStamp != (time.Time{}) {
+		t.Errorf("BackupTimeStamp = %v, want the zero time", di.BackupTimeStamp)
+	}
+
+	if want := time.Date(2022, 8, 10, 2, 18, 11, 0, time.UTC); !di.BuildDate.Equal(want) {
+		t.Errorf("BuildDate = %v, want %v", di.BuildDate, want)
+	}
+}
+
+// TestCrashHistoryUnmarshalJSONSentinelTimestamp verifies that a never-crashed
+// router decodes to the zero value for LastCrashDate.
+func TestCrashHistoryUnmarshalJSONSentinelTimestamp(t *testing.T) {
+	t.Parallel()
+
+	const data = `{
+		"LastCrashDate": "1-01-01T00:00:00+0000",
+		"NumberOfCrash": 0
+	}`
+
+	var ch CrashHistory
+	if err := json.Unmarshal([]byte(data), &ch); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	if ch.LastCrashDate != (time.Time{}) {
+		t.Errorf("LastCrashDate = %v, want the zero time", ch.LastCrashDate)
+	}
+}

--- a/client/types_test.go
+++ b/client/types_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestRadioUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
 	const data = `{
 		"CurrentOperatingChannelBandwidth": "40MHz",
 		"TransmitPower": 75,
@@ -56,6 +58,8 @@ func TestRadioUnmarshalJSONNull(t *testing.T) {
 }
 
 func TestParseTimestamp(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		in      string


### PR DESCRIPTION
This commit addresses three issues encountered:
* Adds handling for "year 1" sentinel in addition to "year 0".
* Adds support for RFC 3339 timestamps
* Moves Radio JSON unmarshalling before transformation code, so that the transformations apply to populated values.